### PR TITLE
Remove empty Drush policy

### DIFF
--- a/drupal8-example/drush/README.md
+++ b/drupal8-example/drush/README.md
@@ -1,1 +1,0 @@
-This directory contains commands, configuration and site aliases for Drush. See https://packagist.org/search/?type=drupal-drush for a directory of Drush commands installable via Composer.


### PR DESCRIPTION
The `policy.drush.inc` is empty which is ... of limited use...

On a few project we have drush policy with actual content in them. They all have the same content: https://github.com/reload/samvirke/blob/b2bda9367cf2d66b880867b53bd2736d8bb71336/drush/policy.drush.inc

Although it could be useful it's mostly a safeguard for preventing a stupid user action.