### PR TITLE
Validate composer.json with Github Actions

### DIFF
--- a/drupal8-example/.github/main.workflow
+++ b/drupal8-example/.github/main.workflow
@@ -1,0 +1,9 @@
+workflow "Validate" {
+  on = "push"
+  resolves = ["Composer validate"]
+}
+
+action "Composer validate" {
+  uses = "pxgamer/composer-action@master"
+  args = "validate --no-check-all --no-check-publish"
+}


### PR DESCRIPTION
Use github actions to validate composer.json.

Unlike Circle, Actions doesn't need to be explicitly enabled on the project to run, so they'll take effect as soon as the project is pushed.
