### PR TITLE
CircleCI cleanup and improvements

### DIFF
--- a/drupal8-example/.circleci/config.yml
+++ b/drupal8-example/.circleci/config.yml
@@ -19,29 +19,31 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo -E apt-get install -y libpng-dev
-
       - run:
           name: Install PHP Extensions
-          command: sudo -E docker-php-ext-install gd
+          command: |
+            sudo -E apt-get install -y libpng-dev
+            sudo -E docker-php-ext-install gd
 
       - run:
           name: Validate composer.json and composer.lock
           command: composer validate --no-check-all --no-check-publish
 
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "composer.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: composer install -n --prefer-dist
+      - run:
+          name: Composer install dependencies
+          command: composer install -n --prefer-dist
 
       - save_cache:
           paths:
             - ./vendor
           key: v1-dependencies-{{ checksum "composer.json" }}
         
-      # run tests!
-      - run: vendor/bin/phpunit
+      - run:
+          name: Run PHP Unit tests
+          command: vendor/bin/phpunit

--- a/drupal8-example/.circleci/config.yml
+++ b/drupal8-example/.circleci/config.yml
@@ -20,6 +20,14 @@ jobs:
       - checkout
 
       - run:
+          name: Install `drupal-check`
+          command: |
+            mkdir -p ~/bin
+            curl --silent --output ~/bin/drupal-check -O -L https://github.com/mglaman/drupal-check/releases/latest/download/drupal-check.phar
+            chmod +x ~/bin/drupal-check
+            ~/bin/drupal-check --version
+
+      - run:
           name: Install PHP Extensions
           command: |
             sudo -E apt-get install -y libpng-dev
@@ -47,3 +55,17 @@ jobs:
       - run:
           name: Run PHP Unit tests
           command: vendor/bin/phpunit
+
+      - run:
+          name: Analysis and check for deprecated code
+          command: |
+            status=0
+            mkdir -p ~/test-results/analysis ~/test-results/deprecations
+            (~/bin/drupal-check --analysis --format=junit --no-progress --no-interaction -- web/modules/custom/ > ~/test-results/analysis/modules.xml) || status=1
+            (~/bin/drupal-check --analysis --format=junit --no-progress --no-interaction -- web/themes/custom/ > ~/test-results/analysis/themes.xml) || status=1
+            (~/bin/drupal-check --deprecations --format=junit --no-progress --no-interaction -- web/modules/custom/ > ~/test-results/deprecations/modules.xml) || status=1
+            (~/bin/drupal-check --deprecations --format=junit --no-progress --no-interaction -- web/themes/custom/ > ~/test-results/deprecations/themes.xml) || status=1
+            exit $status
+
+      - store_test_results:
+          path: ~/test-results


### PR DESCRIPTION
Cleanup CircleCI configuration:
* Add names to runs for better documentation and clarity during run.
* Group related stuff in one run.

Add `drupal-check` to CircleCI:
* Add test run for analysing custom code and checking custom code for deprecated code usage.

The changes are based on experiments using this on [Balder](https://github.com/reload/balder/pull/139) and [Gruppeweb](https://github.com/reload/gruppeweb/pull/262).